### PR TITLE
FE/#17 : 전문가 선택 페이지 API 연동

### DIFF
--- a/lawmon/src/pages/contract/index.tsx
+++ b/lawmon/src/pages/contract/index.tsx
@@ -67,7 +67,7 @@ export default function Contract() {
     },
   });
 
-  type Category = 'RealEstate' | 'Labor' | 'Insurance';
+  type Category = 'REAL_ESTATE' | 'LABOR' | 'INSURANCE';
 
   const handleCategoryClick = (cat: Category) => {
     setCategory(cat);
@@ -118,7 +118,7 @@ export default function Contract() {
     );
   }
 
-  if (mutation.isPending) {
+  if (mutation.isPending) {// 2초 동안 로딩
     return (
       <div>
         <Loading />
@@ -147,21 +147,21 @@ export default function Contract() {
         <div className="button-container flex flex-row items-center space-y-4">
           <button
             className="contract-button flex flex-col items-center justify-center space-y-2 p-4 bg-blue-500 rounded-lg text-white"
-            onClick={() => handleCategoryClick('RealEstate')}
+            onClick={() => handleCategoryClick('REAL_ESTATE')}
           >
             <img src={contractImage} alt="계약서" className="w-10 h-10" />
             <span>부동산 계약서</span>
           </button>
           <button
             className="contract-button flex flex-col items-center justify-center space-y-2 p-4 bg-blue-500 rounded-lg text-white"
-            onClick={() => handleCategoryClick('Labor')}
+            onClick={() => handleCategoryClick('LABOR')}
           >
             <img src={contractImage} alt="계약서" className="w-10 h-10" />
             <span>근로 계약서</span>
           </button>
           <button
             className="contract-button flex flex-col items-center justify-center space-y-2 p-4 bg-blue-500 rounded-lg text-white"
-            onClick={() => handleCategoryClick('Insurance')}
+            onClick={() => handleCategoryClick('INSURANCE')}
           >
             <img src={contractImage} alt="계약서" className="w-10 h-10" />
             <span>보험 계약서</span>

--- a/lawmon/src/pages/expert/Loading.css
+++ b/lawmon/src/pages/expert/Loading.css
@@ -1,0 +1,34 @@
+.loading-dots {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 10vh;
+  width: 200px;
+  gap: 40px;
+}
+
+.dot {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ba90ff; /* 보라색 */
+  animation: bounce 0.8s infinite;
+}
+
+.dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.dot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes bounce {
+  0%, 80%, 100% {
+    transform: scale(1.2);
+    opacity: 0.7;
+  }
+  40% {
+    transform: scale(2.5);
+    opacity: 1;
+  }
+}

--- a/lawmon/src/pages/expert/Loading.tsx
+++ b/lawmon/src/pages/expert/Loading.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import './Loading.css';
+
+export default function Loading() {
+  return (
+    <div>
+        <h1 className="Law-title">LAWMON</h1>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100vh',
+        }}
+      >
+        <div className="loading-dots">
+          <div className="dot purple"></div>
+          <div className="dot purple"></div>
+          <div className="dot purple"></div>
+        </div>
+        <h1>전문가를 불러오는 중 입니다!</h1>
+      </div>
+    </div>
+  );
+}

--- a/lawmon/src/pages/expert/index.tsx
+++ b/lawmon/src/pages/expert/index.tsx
@@ -1,66 +1,56 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import './index.css';
 import expertImage from '/src/assets/윾건이형.png'; // 전문가 프로필 이미지 예제
 import smallStar from '/src/assets/작은별.svg'; // 보라색 채운 별 이미지 경로
 import talk from '../../assets/상담하기.svg';
+import { useQuery } from '@tanstack/react-query';
+import { useContractStore } from 'shared/store/store';
+import Loading from './Loading';
 
 export default function Expert() {
-  const experts = [
-    {
-      name: '현우진',
-      rating: 5,
-      reviews: 18,
-      description: (
-        <b>'20년 경력의 계약 전문가, 당신의 신뢰를 지키는 파트너입니다.'</b>
-      ),
-      education: '(미) 스탠포드대학교 수학과 학사',
-      company1: '대찬학원',
-      company2: '메가스터디',
-      image: expertImage,
-    },
-    {
-      name: '김민지',
-      rating: 4,
-      reviews: 12,
-      description: (
-        <b>'15년 경력의 회계 전문가, 신뢰할 수 있는 재정 관리 파트너입니다.'</b>
-      ),
-      education: '(미) 하버드대학교 경영학 학사',
-      company1: '삼성전자',
-      company2: '현대자동차',
-      image: expertImage,
-    },
-    {
-      name: '이승현',
-      rating: 5,
-      reviews: 22,
-      description: (
-        <b>
-          '10년 경력의 금융 전문가, 안정적이고 효율적인 투자 솔루션을
-          제공합니다.'
-        </b>
-      ),
-      education: '(미) MIT 경영학 석사',
-      company1: 'KB증권',
-      company2: '한국투자증권',
-      image: expertImage,
-    },
 
-    {
-      name: '현우진',
-      rating: 5,
-      reviews: 18,
-      description: (
-        <b>'20년 경력의 계약 전문가, 당신의 신뢰를 지키는 파트너입니다.'</b>
-      ),
-      education: '(미) 스탠포드대학교 수학과 학사',
-      company1: '대찬학원',
-      company2: '메가스터디',
-      image: expertImage,
-    },
+  const category = useContractStore((state) => state.category);
+  const setCategory = useContractStore((state) => state.setCategory); // 지우기
+  useEffect(() => { //지우기
+    setCategory('REAL_ESTATE'); // 지우기
+  }, []);
 
-    // 추가 전문가 데이터를 원하면 여기에 객체 추가 가능
-  ];
+  const { isPending, error, data } = useQuery({
+    queryKey: ['experts', category],
+    queryFn: async () => {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_URL}/api/v1/experts/category/${category}`,
+      );
+      if (!res.ok) {
+        throw new Error('Network response was not ok');
+      }
+      return res.json();
+    },
+    enabled: !!category, // category가 있을 때만 쿼리 실행
+  });
+  console.log('category : ', category);  //지우기
+  console.log('data :', data);  //지우기
+
+  interface ExpertApiResponse {
+    name: string;
+    specialty: string;
+    // 필요한 경우 rating, reviews, education, company1, company2 등 추가
+  }
+
+
+  // data가 배열인지 확인 후 map, 아니면 빈 배열 사용
+  const experts = Array.isArray(data)
+    ? data.map((item: ExpertApiResponse) => ({
+        name: item.name,
+        rating: 5, // 임시값, 실제 rating 필드가 오면 교체
+        reviews: 0, // 임시값, 실제 reviews 필드가 오면 교체
+        description: <b>{item.specialty}</b>, // specialty를 description으로 사용
+        education: '', // 임시값
+        company1: '', // 임시값
+        company2: '', // 임시값
+        image: expertImage,
+      }))
+    : [];
 
   return (
     <div className="expert-container flex flex-col items-center justify-center min-h-screen bg-gradient-to-b from-blue-100 to-white p-6">
@@ -95,7 +85,7 @@ export default function Expert() {
                       />
                     ))}
                   </span>
-                  후기 {expert.reviews}개
+                    &nbsp; 후기 {expert.reviews}개
                 </p>
               </div>
               <div className="flex justify-end ">

--- a/lawmon/src/pages/expert/index.tsx
+++ b/lawmon/src/pages/expert/index.tsx
@@ -10,10 +10,10 @@ import Loading from './Loading';
 export default function Expert() {
 
   const category = useContractStore((state) => state.category);
-  const setCategory = useContractStore((state) => state.setCategory); // 지우기
-  useEffect(() => { //지우기
-    setCategory('REAL_ESTATE'); // 지우기
-  }, []);
+//   const setCategory = useContractStore((state) => state.setCategory); // 지우기
+//   useEffect(() => { //지우기
+//     setCategory('REAL_ESTATE'); // 지우기
+//   }, []);
 
   const { isPending, error, data } = useQuery({
     queryKey: ['experts', category],
@@ -28,8 +28,8 @@ export default function Expert() {
     },
     enabled: !!category, // category가 있을 때만 쿼리 실행
   });
-  console.log('category : ', category);  //지우기
-  console.log('data :', data);  //지우기
+//   console.log('category : ', category);  //지우기
+//   console.log('data :', data);  //지우기
 
   interface ExpertApiResponse {
     name: string;


### PR DESCRIPTION
🛠️ 기능 구현
계약서 파일 업로드 API 연동

✅ 해당 기능을 구현하기 위해 할 일

- [x] 전문가 검색 api 연동
- [x] API response에 따라 구조 변경
- [x] tanstack query로 캐시형태로 데이터 가져오기
- [x] contract 페이지  전역변수 api 형태에 맞게 변형

REAL_ESTATE
![image](https://github.com/user-attachments/assets/85c26665-750d-4809-b2e0-052fa9f86e4b)